### PR TITLE
Added enabled key in postgresql_groups.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -119,7 +119,8 @@
   delegate_to: '{{ postgresql_delegate_to }}'
   when: ((item.roles|d() and item.roles) and
          (item.groups|d() and item.groups) and
-         (item.database|d() and item.database))
+         (item.database|d() and item.database) and
+         (item.enabled is undefined or item.enabled|bool))
 
 - name: Grant database privileges to PostgreSQL roles
   postgresql_user:


### PR DESCRIPTION
Example use case:

```
postgresql_groups:
  - roles: [ '{{ owncloud_database_user }}' ]
    groups: [ '{{ owncloud_database_name }}' ]
    database: '{{ owncloud_database_name }}'
    enabled: '{{ owncloud_database_name != owncloud_database_user }}'
```
